### PR TITLE
Fix backup and restore and ignore media files when backing up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Ignore upgrade data
 
-data/
+backup/
 prestashop/
 results/
 

--- a/app/constants
+++ b/app/constants
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-backupPath='./data'
-resultPath='./results'
-src='./prestashop'
+BACKUP_PATH=$(pwd)'/backup'
+UPDRADE_RESULT_LOG_PATH=$(pwd)'/results'
+PRESTASHOP_SOURCE_PATH=$(pwd)'/prestashop'

--- a/juice/backup
+++ b/juice/backup
@@ -29,6 +29,7 @@ rsync -alv --delete \
     --exclude '/cache/cachefs' \
     --exclude '/themes/*/cache' \
     --exclude '/log' \
+    --exclude '/var' \
     $APPLICATION_PATH/ $BACKUP_PATH/files
 
 if [[ $? == 0 ]]; then

--- a/juice/backup
+++ b/juice/backup
@@ -12,22 +12,24 @@ success "Start backup process"
 
 currentVersion=$(php -r "include '${APPLICATION_PATH}/config/config.inc.php';echo _PS_VERSION_;")
 if [ "$currentVersion" == "$PRESTASHOP_NEW_VERSION" ]; then
-    danger "You are trying to backup the already upgraded $PRESTASHOP_NEW_VERSION version"
+    danger "You are trying to backup the already upgraded ${PRESTASHOP_NEW_VERSION} version"
     exit 1
 else
     success "Backing up the current version"
 fi
 
 # Creating backup directories
-mkdir -p "$backupPath/files"
+mkdir -p "$BACKUP_PATH/files"
 
 # Rsync to backup files
-rsync -azv \
-    --exclude 'cache/cachefs' \
-    --exclude 'themes/*/cache' \
-    --exclude 'log' \
-    --exclude 'var' \
-    "$APPLICATION_PATH/" "$backupPath/files"
+rsync -alv --delete \
+    --exclude '/img' \
+    --exclude '/download' \
+    --exclude '/upload' \
+    --exclude '/cache/cachefs' \
+    --exclude '/themes/*/cache' \
+    --exclude '/log' \
+    $APPLICATION_PATH/ $BACKUP_PATH/files
 
 if [[ $? == 0 ]]; then
     success "Code backup completed"
@@ -36,10 +38,10 @@ else
     exit 1
 fi
 
-if [[ -n $DATABASE_HOST && -n $DATABASE_USER && -n $DATABASE_PASSWORD && -n $DATABASE_NAME ]]; then
+if [[ -n "$DATABASE_HOST" && -n "$DATABASE_USER" && -n "$DATABASE_PASSWORD" && -n "$DATABASE_NAME" ]]; then
 
     # Database backup
-    mysqldump -h$DATABASE_HOST -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME > $backupPath/database.sql
+    mysqldump -h"$DATABASE_HOST" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" "$DATABASE_NAME" > "${BACKUP_PATH}/database.sql"
 
     if [[ $? == 0 ]]; then
         success "Database backup created"

--- a/juice/backup
+++ b/juice/backup
@@ -42,7 +42,11 @@ fi
 if [[ -n "$DATABASE_HOST" && -n "$DATABASE_USER" && -n "$DATABASE_PASSWORD" && -n "$DATABASE_NAME" ]]; then
 
     # Database backup
-    mysqldump -h"$DATABASE_HOST" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" "$DATABASE_NAME" > "${BACKUP_PATH}/database.sql"
+    mysqldump --single-transaction \
+        -h"$DATABASE_HOST" \
+        -u"$DATABASE_USER" \
+        -p"$DATABASE_PASSWORD" \
+        "$DATABASE_NAME" > "${BACKUP_PATH}/database.sql"
 
     if [[ $? == 0 ]]; then
         success "Database backup created"

--- a/juice/check
+++ b/juice/check
@@ -63,7 +63,7 @@ if [[ -z $DATABASE_PREFIX ]]; then
 fi
 
 # Check for backup existence
-if [[ ! -f "${backupPath}/files/config/settings.inc.php" ]]; then
+if [[ ! -f "${BACKUP_PATH}/files/config/settings.inc.php" ]]; then
   danger "No backup found. Please create a backup first."
 fi
 

--- a/juice/restore
+++ b/juice/restore
@@ -35,6 +35,10 @@ rsync -alv --delete \
     --exclude '/img' \
     --exclude '/download' \
     --exclude '/upload' \
+    --exclude '/cache/cachefs' \
+    --exclude '/themes/*/cache' \
+    --exclude '/log' \
+    --exclude '/var' \
     $BACKUP_PATH/files/ $APPLICATION_PATH
 
 if [ $? == 0 ]; then

--- a/juice/restore
+++ b/juice/restore
@@ -8,7 +8,7 @@ source app/functions
 
 success "Start restore process"
 
-mkdir -p $backupPath
+mkdir -p $BACKUP_PATH
 
 if [ $(php -r "include('${APPLICATION_PATH}/config/config.inc.php');echo _PS_VERSION_;") == $PRESTASHOP_OLD_VERSION ]; then
     warning "You are restoring a backup while your current appliation is not upgraded."
@@ -23,7 +23,7 @@ if [ $(php -r "include('${APPLICATION_PATH}/config/config.inc.php');echo _PS_VER
     fi
 fi
 
-mysql -h$DATABASE_HOST -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME < $backupPath/database.sql
+mysql -h"$DATABASE_HOST" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" "$DATABASE_NAME" < "$BACKUP_PATH/database.sql"
 
 if [[ $? == 0 ]]; then
     success "Database restored"
@@ -31,7 +31,11 @@ else
     warning "mysql import went wrong giving exit code $?"
 fi
 
-rsync -azv --exclude 'cache/cachefs' $backupPath/files/* $APPLICATION_PATH
+rsync -alv --delete \
+    --exclude '/img' \
+    --exclude '/download' \
+    --exclude '/upload' \
+    $BACKUP_PATH/files/ $APPLICATION_PATH
 
 if [ $? == 0 ]; then
     success "rsync was success fully completed"
@@ -42,6 +46,11 @@ fi
 rm -rf "$APPLICATION_PATH/cache/smarty/compile" \
     "$APPLICATION_PATH/cache/class_index.php" \
     "$APPLICATION_PATH/var/"
+
+rm -rf "$APPLICATION_PATH/cache/smarty/compile" \
+       "$APPLICATION_PATH/cache/cachefs" \
+       "$APPLICATION_PATH/cache/class_index.php" \
+       "$APPLICATION_PATH/var/cache/"
 
 if [[ $? == 0 ]]; then
     success "Remove cache files completed"

--- a/juice/upgrade
+++ b/juice/upgrade
@@ -63,25 +63,25 @@ fi
           fi
         fi
 
-        rm -rf $src
-        mkdir -p $src
+        rm -rf $PRESTASHOP_SOURCE_PATH
+        mkdir -p $PRESTASHOP_SOURCE_PATH
 
         info "Unzipping the new release"
-        unzip -o "$releaseZip" -d "$src"
+        unzip -o "$releaseZip" -d "$PRESTASHOP_SOURCE_PATH"
 
         if [[ $? != 0 ]]; then
           danger "Unzip failed, exit $?"
         fi
 
         # Unzipping the inner prestashop.zip
-        unzip -o "$src/prestashop.zip" -d "$src"
+        unzip -o "$PRESTASHOP_SOURCE_PATH/prestashop.zip" -d "$PRESTASHOP_SOURCE_PATH"
       fi
 
       # Add custom exclude list config/exclude-list-custom.txt
             rsync -avz \
               --keep-dirlinks \
               --exclude-from="config/exclude-list-custom.txt" \
-              $src/* $APPLICATION_PATH
+              $PRESTASHOP_SOURCE_PATH/* $APPLICATION_PATH
 
       info "Copying new release in application folder"
 
@@ -112,11 +112,11 @@ fi
         warning "Command 'sed' could not manipulate $defines_inc_php, exit code $?"
       fi
 
-      mkdir -p "$resultPath"
+      mkdir -p "$UPDRADE_RESULT_LOG_PATH"
 
       info "Starting the upgrade process"
 
-      curlOutPut=$(curl --write-out %{http_code} --silent --output "$resultPath/results.xml" "$SHOP_URL/install/upgrade/upgrade.php")
+      curlOutPut=$(curl --write-out %{http_code} --silent --output "$UPDRADE_RESULT_LOG_PATH/results.xml" "$SHOP_URL/install/upgrade/upgrade.php")
 
       if [[ ! -f $APPLICATION_PATH/install/index.php ]]; then
         danger "Upgrade file not available."


### PR DESCRIPTION
Fixes #39 #40

- add slashed before folder names to only target the app root folder, like /log, if this is not done, ALL folders named "log" are not backedup or restored!
- refactor constant names for readability
- rename backup path from data to backup